### PR TITLE
Incremental Model - Technical Test ST

### DIFF
--- a/models/revenue/cleansed_transactions.sql
+++ b/models/revenue/cleansed_transactions.sql
@@ -1,0 +1,28 @@
+{{
+    config(
+        materialized='table'
+    )
+}}
+
+select rc_original_app_user_id as subscriber_id
+  , cast(store_transaction_id as text) as transaction_id
+  , cast(original_store_transaction_id as text) as first_user_purchase_transaction_id
+  , cast(country as text) as country 
+  , cast(platform as text) as platform
+  , cast(product_identifier as text) as plan_id
+  , datetime(start_time) as subscription_starts_at
+  , datetime(end_time) as subscription_expires_at
+  , cast(store as text) as transaction_source
+  , 'USD' as currency
+  , round(cast(price_in_usd as real), 2) as price
+  , cast(takehome_percentage as real) * 100 as proceeds_percentage
+  , cast(renewal_number as integer) as transaction_rank
+  , cast(is_auto_renewable as integer) as is_auto_renewable
+  , cast(is_trial_period as integer) as is_trial
+  , datetime(refunded_at) as refunded_at
+  , datetime(unsubscribe_detected_at) as unscribe_detected_at
+  , datetime(billing_issues_detected_at) as billing_issues_detected_at
+  , datetime('2022-01-01 00:00:00.000') as inserted_at -- dummy timestamp for subsequent incremental model
+from {{ source('staging', 'revenuecat_hint') }}
+  where is_sandbox = false 
+  and transaction_source != 'promotional'

--- a/models/revenue/integrated_dim_transactions.sql
+++ b/models/revenue/integrated_dim_transactions.sql
@@ -1,0 +1,37 @@
+{{
+    config(
+        materialized='incremental'
+    )
+}}
+
+select subscriber_id
+  , transaction_id
+  , first_user_purchase_transaction_id
+  , country 
+  , platform
+  , plan_id
+  , subscription_starts_at
+  , subscription_expires_at
+  , transaction_source
+  , currency
+  , price
+  , proceeds_percentage
+  , round(price * proceeds_percentage / 100, 2) as proceeds
+  , transaction_rank
+  , case when refunded_at is null then 0 else 1 end as is_refunded
+  , case when unsubscribe_detected_at is null then 0 else 1 end as is_unsubscribed
+  , case when billing_issues_detected_at is null then 0 else 1 end is_billing_issue_detected
+  , is_auto_renewable
+  , is_trial
+  , refunded_at
+  , unsubscribe_detected_at
+  , billing_issues_detected_at
+  , inserted_at
+from {{ ref('cleansed_transactions') }}
+
+{% if is_incremental() %}
+
+  -- limit to rows inserted since last incremental run
+  where inserted_at > (select max(inserted_at) from {{ this }})
+
+{% endif %}


### PR DESCRIPTION
### Description

This short dummy PR is for a technical test assigned on Feb 7. The task is to build an incremental model showing the current state of each transaction using only data ingested since the last incremental run. The changes are summarised below:

- A cleansed model and an (incremental) integrated model are built: the former handles data types and naming, while the incremental model adds a few columns with some logic regarding transaction states.
- The models are for now placed in the path `rubylabs-dbt/models/revenue/`. However, one with more knowledge about the business context may very well organise the models differently.
- Some source columns that are apparently less relevant / with unclear purpose are omitted in the models. Tests have also not been added, considering the limited familiarity of the data regarding things such as uniqueness of certain columns. A better built might require a more in-depth understanding of the data, which might not be the primary purpose of this task.